### PR TITLE
Start using json-mapper 2.x-dev; Fix failing tests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,8 +26,8 @@
         "ext-json": "*",
         "guzzlehttp/guzzle": "^7.0",
         "illuminate/support": "^6.0|^7.0|^8.0",
-        "json-mapper/json-mapper": "^1.3.0",
-        "json-mapper/laravel-package": "^1.1.3"
+        "json-mapper/json-mapper": "^2.0",
+        "json-mapper/laravel-package": "^2.0"
     },
     "require-dev": {
         "orchestra/testbench": "4.*|5.*|8.*",

--- a/src/Entity/Account.php
+++ b/src/Entity/Account.php
@@ -35,7 +35,7 @@ class Account
 
     public bool $active;
 
-    public string $batch_id;
+    public ?string $batch_id;
 
     public int $created_at;
 

--- a/src/Entity/Contact.php
+++ b/src/Entity/Contact.php
@@ -29,7 +29,7 @@ class Contact
 
     public string $reference_id;
 
-    public string $batch_id;
+    public ?string $batch_id;
 
     public bool $active;
 

--- a/src/Entity/Payment.php
+++ b/src/Entity/Payment.php
@@ -29,7 +29,7 @@ class Payment
 
     public bool $queue_if_low_balance;
 
-    public string $reference_id;
+    public ?string $reference_id;
 
     public string $narration;
 
@@ -45,11 +45,11 @@ class Payment
 
     public string $status;
 
-    public string $utr;
+    public ?string $utr;
 
-    public string $batch_id;
+    public ?string $batch_id;
 
-    public string $failure_reason;
+    public ?string $failure_reason;
 
     public int $created_at;
 


### PR DESCRIPTION
This PR start using the JsonMapper 2.x branch which is prepared for an upcoming v2 release.
After updating to the 2.x branch some test where failing due to the null detection which is now part of JsonMapper.
After reading through the RazorPay API docs I noticed the response fields where optional which I've updated to reflect so.

In order to complete this PR and get a review the following tasks need to be completed.
- [x]  json-mapper/json-mapper V2 should be released
- [x]  json-mapper/laravel-package V2 should be released.
- [x] PR should be updated to target ^2.0 version of both the core and laravel package